### PR TITLE
Gem is for ruby, module is for node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IronWorker is a massively scalable background processing system.
 # Getting Started
 
 
-1\. Install the gem:
+1\. Install the module:
 
 ```
 npm install iron_worker


### PR DESCRIPTION
It is better to name "module" instead of "gem" for node. "Gem" is for Ruby.