### PR TITLE
Added method to allow for bulk creation of tasks with a single API call

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -113,16 +113,19 @@
       });
     };
 
-    APIClient.prototype.tasksCreate = function(codeName, payload, options, cb) {
-      var parseResponseBind;
+    APIClient.prototype.tasksCreate = function(tasks, cb) {
+      var parseResponseBind, tasksFormatted;
       parseResponseBind = _.bind(this.parseResponse, this);
+      tasksFormatted = tasks.map((function(_this) {
+        return function(task) {
+          return _.extend({
+            code_name: task.codeName,
+            payload: typeof task.payload === 'string' ? task.payload : JSON.stringify(task.payload)
+          }, task.options);
+        };
+      })(this));
       return this.post("projects/" + this.options.project_id + "/tasks", {
-        'tasks': [
-          _.extend({
-            'code_name': codeName,
-            'payload': payload
-          }, options)
-        ]
+        tasks: tasksFormatted
       }, function(error, response, body) {
         return parseResponseBind(error, response, body, cb);
       });

--- a/lib/client.js
+++ b/lib/client.js
@@ -85,21 +85,24 @@
       });
     };
 
-    Client.prototype.tasksCreate = function(codeName, params, options, cb) {
-      var payload;
-      payload = '';
-      if (typeof params === 'string') {
-        payload = params;
-      } else {
-        payload = JSON.stringify(params);
-      }
-      return this.api.tasksCreate(codeName, payload, options, function(error, body) {
+    Client.prototype.tasksCreateBulk = function(tasks, cb) {
+      return this.api.tasksCreate(tasks, function(error, body) {
         if (error == null) {
           return cb(error, body.tasks[0]);
         } else {
           return cb(error, body);
         }
       });
+    };
+
+    Client.prototype.tasksCreate = function(codeName, params, options, cb) {
+      return this.tasksCreateBulk([
+        {
+          codeName: codeName,
+          payload: payload,
+          options: options
+        }
+      ], cb);
     };
 
     Client.prototype.tasksRetry = function(taskId, delay, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -95,7 +95,7 @@
       });
     };
 
-    Client.prototype.tasksCreate = function(codeName, params, options, cb) {
+    Client.prototype.tasksCreate = function(codeName, payload, options, cb) {
       return this.tasksCreateBulk([
         {
           codeName: codeName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iron_worker",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Node client for IronWorker",
   "homepage": "https://github.com/iron-io/iron_worker_node",
   "author": "Andrew Kirilenko & Iron.io, Inc",

--- a/src/api_client.coffee
+++ b/src/api_client.coffee
@@ -87,10 +87,18 @@ class APIClient extends ironCore.Client
       parseResponseBind(error, response, body, cb)
     )
 
-  tasksCreate: (codeName, payload, options, cb) ->
+  tasksCreate: (tasks, cb) ->
     parseResponseBind = _.bind(@parseResponse, @)
 
-    @post("projects/#{@options.project_id}/tasks", {'tasks': [_.extend({'code_name': codeName, 'payload': payload}, options)]}, (error, response, body) ->
+    tasksFormatted = tasks.map (task) => _.extend(
+      {
+        code_name: task.codeName,
+        payload: if typeof(task.payload) == 'string' then task.payload else JSON.stringify(task.payload)
+      },
+      task.options
+    )
+
+    @post("projects/#{@options.project_id}/tasks", {tasks: tasksFormatted}, (error, response, body) ->
       parseResponseBind(error, response, body, cb)
     )
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -71,7 +71,7 @@ class Client
         cb(error, body)
     )
 
-  tasksCreate: (codeName, params, options, cb) ->
+  tasksCreate: (codeName, payload, options, cb) ->
     @tasksCreateBulk([{ codeName, payload, options }], cb)
 
   tasksRetry: (taskId, delay, cb) ->

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -63,20 +63,16 @@ class Client
         cb(error, body)
     )
 
-  tasksCreate: (codeName, params, options, cb) ->
-    payload = ''
-
-    if typeof(params) == 'string'
-      payload = params
-    else
-      payload = JSON.stringify(params)
-
-    @api.tasksCreate(codeName, payload, options, (error, body) ->
+  tasksCreateBulk: (tasks, cb) ->
+    @api.tasksCreate(tasks, (error, body) ->
       if not error?
         cb(error, body.tasks[0])
       else
         cb(error, body)
     )
+
+  tasksCreate: (codeName, params, options, cb) ->
+    @tasksCreateBulk([{ codeName, payload, options }], cb)
 
   tasksRetry: (taskId, delay, cb) ->
     @api.tasksRetry(taskId, delay, (error, body) ->


### PR DESCRIPTION
* Refactored `APIClient.tasksCreate()` to expect being passed an array of tasks
* Added `Client.tasksCreateBulk()` method
* Refactored `Client.tasksCreate()` to call `Client.tasksCreateBulk()`